### PR TITLE
Merge HU13-LQ-POST-Create Attribute

### DIFF
--- a/src/data/attributes.py
+++ b/src/data/attributes.py
@@ -7,20 +7,21 @@ import time
 
 fake = Faker()
 
-
-def generate_attributes_source_data():
-    # Generar un código único combinando timestamp y uuid
-    timestamp = str(int(time.time()))[-6:]
-    unique_id = str(uuid.uuid4())[:8]  #
-
-    attributes_data = {
-        "code": f"test_{timestamp}_{unique_id}",
+def generate_attributes_source_data(required_only=False):
+    code = fake.unique.slug()
+    name = fake.unique.company()
+    payload = {
+        "code": code,
         "type": "text",
         "translations": {
             "en_US": {
-                "name": f"{fake.company()} - {fake.catch_phrase()}"
+                "name": name
             }
-        }
+        },
+        "configuration": {
+            "maxCharacters": fake.random_int(min=10, max=200),
+            "minCharacters": fake.random_int(min=1, max=10)
+        },
+        "storageType": "text"
     }
-    return attributes_data
-
+    return payload

--- a/tests/catalog/attributes/test_HU13_LQ_POST_Attributes.py
+++ b/tests/catalog/attributes/test_HU13_LQ_POST_Attributes.py
@@ -1,0 +1,40 @@
+import pytest
+
+from src.assertions.attributes_assertions import AssertionAttributes
+from src.assertions.status_code_assertions import AssertionStatusCode
+from src.routes.endpoint_attributes import EndpointAttributes
+from src.routes.request import SyliusRequest
+from src.data.attributes import generate_attributes_source_data
+from utils.logger_helpers import log_request_response
+
+
+@pytest.mark.smoke
+@pytest.mark.functional
+#Verificar que se permita crear un nuevo atributo en catalagos de la aplicacion Sylius.
+#Verificar que se muestre un status code 201
+def test_TC51_Verificar_que_se_permita_crear_nuevo_attribute_en_catalagos(setup_add_attributes):
+    headers, created_attributes = setup_add_attributes
+    payload = generate_attributes_source_data()
+    response = SyliusRequest.post(EndpointAttributes.attributes(), headers, payload)
+    log_request_response(EndpointAttributes.attributes(), response, headers, payload)
+    AssertionStatusCode.assert_status_code_201(response)
+    AssertionAttributes.assert_attributes_post_output_schema(response.json())
+    created_attributes.append(response.json())
+
+
+@pytest.mark.functional
+@pytest.mark.smoke
+@pytest.mark.positive
+#Verificar que se permita crear un nuevo atributo con campos requeridos.
+#Verificar que se muestre un status code 201
+def test_TC52_Verificar_que_se_permita_crear_un_atributo_con_campos_requeridos(setup_add_attributes):
+    headers, created_attributes = setup_add_attributes
+    payload = generate_attributes_source_data()
+    url = EndpointAttributes.attributes()
+    response = SyliusRequest.post(url, headers, payload)
+    AssertionStatusCode.assert_status_code_201(response)
+    AssertionAttributes.assert_attributes_post_input_schema(payload)
+    AssertionAttributes.assert_attributes_post_output_schema(response.json())
+    assert response.json()["code"] == payload["code"]
+    assert response.json()["translations"]["en_US"]["name"] == payload["translations"]["en_US"]["name"]
+


### PR DESCRIPTION
Se subieron los test automatizados de los sigueintes TCs:

- test_TC51_Verificar_que_se_permita_crear_nuevo_attribute_en_catalagos
- test_TC52_Verificar_que_se_permita_crear_un_atributo_con_campos_requeridos