### PR TITLE
Merge HU23-LQ-DELETE-ATTRIBUTES

### DIFF
--- a/tests/catalog/attributes/test_HU12_LQ_PUT_Attributes.py
+++ b/tests/catalog/attributes/test_HU12_LQ_PUT_Attributes.py
@@ -13,7 +13,7 @@ from utils.logger_helpers import log_request_response
 
 #Admin> Catalog> Attributes TC_47: No se debe permitir actualizar si el atributo no existe.
 @pytest.mark.functional
-@pytest.mark.regression
+@pytest.mark.smoke
 def test_TC47_Verificar_que_no_permitar_actualizar_un_atributo_inexistente(auth_headers):
     update_data = generate_attributes_source_data()
     url = EndpointAttributes.code("codigo_inexistente_123")
@@ -23,7 +23,6 @@ def test_TC47_Verificar_que_no_permitar_actualizar_un_atributo_inexistente(auth_
 
 
 #Admin> Catalog> Attributes TC_48: No se debe permitir actualizar un atributo sin token.
-@pytest.mark.regression
 @pytest.mark.security
 @pytest.mark.smoke
 def test_TC48_Verificar_que_no_se_permita_actualizar_atributo_sin_token():
@@ -78,7 +77,6 @@ def test_TC44_Verificar_se_actualice_attributo_con_datos_validos(setup_attribute
 # Admin> Catalog> Attributes> TC_46: No se debe permitir actualizar un atributo sin el campo name.
 @pytest.mark.smoke
 @pytest.mark.functional
-@pytest.mark.regression
 def test_TC46_Verificar_actualizar_grupo_sin_el_campo_name(setup_attributes_cleanup):
     auth_headers, add_attributes_for_cleanup = setup_attributes_cleanup
 
@@ -103,7 +101,7 @@ def test_TC46_Verificar_actualizar_grupo_sin_el_campo_name(setup_attributes_clea
 
 # Admin> Catalog> Attributes> TC_249: Se permite actualizar un atributo con caracteres especiales en el campo name.
 @pytest.mark.functional
-@pytest.mark.regression
+@pytest.mark.smoke
 def test_TC249_Verificar_actualizar_atributo_con_caracteres_especiales_en_name(setup_attributes_cleanup):
     auth_headers, add_attributes_for_cleanup = setup_attributes_cleanup
 
@@ -127,9 +125,8 @@ def test_TC249_Verificar_actualizar_atributo_con_caracteres_especiales_en_name(s
 
 
 # Admin> Catalog> Attributes> TC_250: No se permite actualizar un atributo si la autenticacion del token fallo.
-@pytest.mark.functional
 @pytest.mark.security
-@pytest.mark.regression
+@pytest.mark.smoke
 def test_TC250_Verificar_no_actualizar_attribute_con_token_invalido():
     codigo_existente = "retail"
     data = {
@@ -145,7 +142,7 @@ def test_TC250_Verificar_no_actualizar_attribute_con_token_invalido():
 
 # Admin> Catalog> Attributes> TC_251: No se permite actualizar un atributo si el body-json es incorrecto.
 @pytest.mark.functional
-@pytest.mark.regression
+@pytest.mark.smoke
 def test_TC251_Verificar_actualizar_atributo_json_body_incompleto(setup_attributes_cleanup):
     auth_headers, add_attributes_for_cleanup = setup_attributes_cleanup
 
@@ -170,7 +167,7 @@ def test_TC251_Verificar_actualizar_atributo_json_body_incompleto(setup_attribut
 
 # Admin> Catalog> Attributes> TC_354: No see permite actualizar un atributo si el content type es incorrecto.
 @pytest.mark.functional
-@pytest.mark.regression
+@pytest.mark.smoke
 def test_TC354_Verificar_actualizar_atributo_con_content_type_incorrecto(setup_attributes_cleanup):
     auth_headers, add_attributes_for_cleanup = setup_attributes_cleanup
 
@@ -201,7 +198,7 @@ def test_TC354_Verificar_actualizar_atributo_con_content_type_incorrecto(setup_a
 
 # Admin> Catalog> Attributes> TC_353: Validar los header de respuesta despues de la actualizacion del atributo.
 @pytest.mark.functional
-@pytest.mark.regression
+@pytest.mark.smoke
 def test_TC353_Verificar_headers_response_despues_actualizar_attribute(setup_attributes_cleanup):
     auth_headers, add_attributes_for_cleanup = setup_attributes_cleanup
     data = generate_attributes_source_data()

--- a/tests/catalog/attributes/test_HU13_LQ_POST_Attributes.py
+++ b/tests/catalog/attributes/test_HU13_LQ_POST_Attributes.py
@@ -25,7 +25,6 @@ def test_TC49_Verificar_que_se_permita_crear_nuevo_atributo(setup_add_attributes
 # Admin> Catalog> Attributes> TC_50: Despues de crear un atributo validar la estructura del JSON.
 @pytest.mark.functional
 @pytest.mark.smoke
-@pytest.mark.regression
 def test_TC50_Verificar_la_estructura_json_response_despues_de_crear_atributp(setup_attributes_cleanup):
     auth_headers, add_attributes_for_cleanup = setup_attributes_cleanup
 
@@ -43,7 +42,6 @@ def test_TC50_Verificar_la_estructura_json_response_despues_de_crear_atributp(se
 # Admin> Catalog> Attributes> TC_51: No debe crearse un nuevo atributo sin el campo requerido name.
 @pytest.mark.smoke
 @pytest.mark.functional
-@pytest.mark.regression
 def test_TC51_Verificar_no_crear_atributo_sin_campo_name(auth_headers):
     data = generate_attributes_source_data()
     del data["translations"]["en_US"]["name"]
@@ -57,7 +55,6 @@ def test_TC51_Verificar_no_crear_atributo_sin_campo_name(auth_headers):
 
 # Admin> Catalog> Attributes> TC_52: No debe crearse un nuevo atributo sin el campo  code.
 @pytest.mark.smoke
-@pytest.mark.regression
 @pytest.mark.functional
 def test_TC52_Verificar_no_crear_atributo_sin_campo_code(auth_headers):
     data = generate_attributes_source_data()
@@ -71,7 +68,6 @@ def test_TC52_Verificar_no_crear_atributo_sin_campo_code(auth_headers):
 
 # Admin> Catalog> Attributes> TC_410: No debe crearse un nuevo atributo con una name mayor a 255 caracteres.
 @pytest.mark.smoke
-@pytest.mark.regression
 @pytest.mark.functional
 def test_TC410_Verificar_no_crear_atributo_con_nombre_mayor_255caracteres(auth_headers):
     data = generate_attributes_source_data()
@@ -84,9 +80,8 @@ def test_TC410_Verificar_no_crear_atributo_con_nombre_mayor_255caracteres(auth_h
 
 
 # Admin> Catalog> Attributes> TC_411: No debe crearse un nuevo atributo sin token de autenticacion.
-@pytest.mark.functional
+@pytest.mark.smoke
 @pytest.mark.security
-@pytest.mark.regression
 def test_TC411_Verificar_no_crear_atributo_sin_token_autentication():
     data = generate_attributes_source_data()
     url = EndpointAttributes.attributes()
@@ -99,7 +94,6 @@ def test_TC411_Verificar_no_crear_atributo_sin_token_autentication():
 # Admin> Catalog> Attributes> TC_412: No debe crearse un nuevo atributo con token de invalido.
 @pytest.mark.functional
 @pytest.mark.security
-@pytest.mark.regression
 def test_TC412_Verificar_no_crear_atributo_con_token_invalido():
     data = generate_attributes_source_data()
     invalid_token = {"Authorization": "Bearer token_invalido"}
@@ -112,8 +106,7 @@ def test_TC412_Verificar_no_crear_atributo_con_token_invalido():
 
 # Admin> Catalog> Attributes> TC_413: El response time debe ser menor a 5 segundos.
 @pytest.mark.functional
-@pytest.mark.performance
-@pytest.mark.regression
+@pytest.mark.smoke
 def test_TC413_Verificar_tiempo_respuesta_creacion_de_un_atributo(setup_attributes_cleanup):
     auth_headers, add_attribute_for_cleanup = setup_attributes_cleanup
 
@@ -133,7 +126,7 @@ def test_TC413_Verificar_tiempo_respuesta_creacion_de_un_atributo(setup_attribut
 
 # Admin> Catalog> Attributes> TC_414: Verificar headers de respuesta despues de crear un atributo.
 @pytest.mark.functional
-@pytest.mark.regression
+@pytest.mark.smoke
 def test_TC414_Verificar_headers_respuesta_despues_de_crear_atributo(setup_attributes_cleanup):
     auth_headers, add_attributes_for_cleanup = setup_attributes_cleanup
 
@@ -154,7 +147,7 @@ def test_TC414_Verificar_headers_respuesta_despues_de_crear_atributo(setup_attri
 
 # Admin> Catalog> Attributes> TC_415: No debe crearse un atributo si el JSON Body es incorrecto.
 @pytest.mark.functional
-@pytest.mark.regression
+@pytest.mark.smoke
 def test_TC415_Verificar_no_crear_atributo_json_incorrecto(auth_headers):
     import requests
     url = EndpointAttributes.attributes()

--- a/tests/catalog/attributes/test_HU23_LQ_DELETE_Attributes.py
+++ b/tests/catalog/attributes/test_HU23_LQ_DELETE_Attributes.py
@@ -1,0 +1,135 @@
+import pytest
+import time
+
+from src.assertions.status_code_assertions import AssertionStatusCode
+from src.routes.endpoint_attributes import EndpointAttributes
+from src.routes.request import SyliusRequest
+from src.data.attributes import generate_attributes_source_data
+from utils.logger_helpers import log_request_response
+
+
+@pytest.mark.functional
+@pytest.mark.smoke
+#Admin> Catalog> Attributes TC_138: Se debe permitir eliminar un atributo existente.
+def test_TC138_Verificar_eliminar_atributo_existente(auth_headers):
+
+    data = generate_attributes_source_data()
+    url = EndpointAttributes.attributes()
+    create_response = SyliusRequest.post(url, auth_headers, data)
+    AssertionStatusCode.assert_status_code_201(create_response)
+    attributes_code = create_response.json()["code"]
+    endpoint = EndpointAttributes.code(attributes_code)
+    response = SyliusRequest.delete(endpoint, auth_headers)
+    log_request_response(endpoint, response, headers=auth_headers)
+    AssertionStatusCode.assert_status_code_204(response)
+
+
+@pytest.mark.functional
+@pytest.mark.smoke
+#Admin> Catalog> Attributes TC_139: No se debe permitir eliminar un atributo con code inexistente.
+def test_TC139_Verificar_que_no_se_permita_eliminar_atributo_con_code_inexistente(auth_headers):
+    code_inexistente = "000" #code inexistente
+    endpoint = EndpointAttributes.code(code_inexistente)
+    response = SyliusRequest.delete(endpoint, auth_headers)
+    log_request_response(endpoint, response, headers=auth_headers)
+    AssertionStatusCode.assert_status_code_404(response)
+
+
+@pytest.mark.security
+@pytest.mark.smoke
+#Admin> Catalog> Attributes TC_140: No se debe permitir eliminar un atributo sin autenticacion del token.
+def test_TC140_Verificar_que_no_se_permita_eliminar_atributo_sin_token():
+    code_existe = "t_shirt_brand"
+    url = EndpointAttributes.code(code_existe)
+    response = SyliusRequest.delete(url, {})
+    log_request_response(url, response, headers={})
+    AssertionStatusCode.assert_status_code_401(response)
+
+
+@pytest.mark.smoke
+#Admin> Catalog> Attributes TC_405: Validar headers-response despues de eliminar el atributo.
+def test_TC405_verificar_los_headers_respuesta_despues_de_eliminar_atributo(auth_headers):
+    data = generate_attributes_source_data()
+    url = EndpointAttributes.attributes()
+    create_response = SyliusRequest.post(url, auth_headers, data)
+    AssertionStatusCode.assert_status_code_201(create_response)
+    attributes_code = create_response.json()["code"]
+    endpoint = EndpointAttributes.code(attributes_code)
+    response = SyliusRequest.delete(endpoint, auth_headers)
+
+    log_request_response(endpoint, response, headers=auth_headers)
+    AssertionStatusCode.assert_status_code_204(response)
+    assert response.content == b"" or len(response.content) == 0
+
+
+@pytest.mark.functional
+@pytest.mark.smoke
+#Admin> Catalog> Attributes TC_406: El atributo eliminado no debe obtenerse con un GET.
+def test_TC406_Verificar_que_el_atributo_eliminado_no_se_muestre(auth_headers):
+    data = generate_attributes_source_data()
+    url = EndpointAttributes.attributes()
+    create_response = SyliusRequest.post(url, auth_headers, data)
+    AssertionStatusCode.assert_status_code_201(create_response)
+
+    attributes_code = create_response.json()["code"]
+
+    delete_endpoint = EndpointAttributes.code(attributes_code)
+    delete_response = SyliusRequest.delete(delete_endpoint, auth_headers)
+    AssertionStatusCode.assert_status_code_204(delete_response)
+
+    get_endpoint = EndpointAttributes.code(attributes_code)
+    get_response = SyliusRequest.get(get_endpoint, auth_headers)
+
+    log_request_response(get_endpoint, get_response, headers=auth_headers)
+    AssertionStatusCode.assert_status_code_404(get_response)
+
+
+@pytest.mark.security
+@pytest.mark.smoke
+#Admin> Catalog> Attributes TC_407: No debe eliminarse un atributo cuando se genera un token invalido.
+def test_TC407_Verificar_no_permitir_eliminar_atributo_con_token_invalido():
+    code_existe = "t_shirt_brand"
+    invalid_headers = {"Authorization": "Bearer token_invalido"}
+    url = EndpointAttributes.code(code_existe)
+    response = SyliusRequest.delete(url, invalid_headers)
+
+    log_request_response(url, response, headers=invalid_headers)
+    AssertionStatusCode.assert_status_code_401(response)
+
+
+@pytest.mark.functional
+@pytest.mark.smoke
+#Admin> Catalog> Attributes TC_408: El tiempo de respuesta despues de eliminar un atributo debe ser menor a 5 sec.
+def test_TC408_verificar_el_tiempo_respuesta_despues_de_eliminar_atributo(auth_headers):
+    data = generate_attributes_source_data()
+    url = EndpointAttributes.attributes()
+    create_response = SyliusRequest.post(url, auth_headers, data)
+    AssertionStatusCode.assert_status_code_201(create_response)
+    attributes_code = create_response.json()["code"]
+
+    start_time = time.time()
+    endpoint = EndpointAttributes.code(attributes_code)
+    response = SyliusRequest.delete(endpoint, auth_headers)
+    elapsed = time.time() - start_time
+    log_request_response(endpoint, response, headers=auth_headers)
+    AssertionStatusCode.assert_status_code_204(response)
+    assert elapsed < 5.0
+
+
+@pytest.mark.functional
+@pytest.mark.smoke
+#Admin> Catalog> Attributes TC_409: Validar los headers-response despues de eliminar un atributo.
+def test_TC409_Verificar_los_headers_respuesta_despues_de_eliminar_atributo(auth_headers):
+    data = generate_attributes_source_data()
+    url = EndpointAttributes.attributes()
+    create_response = SyliusRequest.post(url, auth_headers, data)
+    AssertionStatusCode.assert_status_code_201(create_response)
+
+    attributes_code = create_response.json()["code"]
+
+    endpoint = EndpointAttributes.code(attributes_code)
+    response = SyliusRequest.delete(endpoint, auth_headers)
+
+    log_request_response(endpoint, response, headers=auth_headers)
+    AssertionStatusCode.assert_status_code_204(response)
+    assert response.content == b"" or len(response.content) == 0

--- a/tests/catalog/attributes/test_HU32_LQ_E2E_Attributes.py
+++ b/tests/catalog/attributes/test_HU32_LQ_E2E_Attributes.py
@@ -10,14 +10,13 @@ from utils.logger_helpers import log_request_response
 @pytest.mark.functional
 @pytest.mark.smoke
 @pytest.mark.regression
-# Admin> Catalog> Attributes> TC_416: Este test E2E  valida los metodos POST-GET-DELETE-GET de un atributo.
+# Admin> Catalog> Attributes> TC_416: Este  E2E flujo de creacion, listar, eliminar y validar que se elimine el atributo.
 def test_TC416_e2e_attributes(auth_headers):
     # Crear nuevo atributo (POST)
     data = generate_attributes_source_data()
     url = EndpointAttributes.attributes()
     response_post = SyliusRequest.post(url, auth_headers, data)
     log_request_response(url, response_post, headers=auth_headers, payload=data)
-    AssertionStatusCode.assert_status_code_201(response_post)
 
     created_attribute = response_post.json()
     attribute_code = created_attribute["code"]
@@ -26,17 +25,11 @@ def test_TC416_e2e_attributes(auth_headers):
     get_endpoint = EndpointAttributes.code(attribute_code)
     get_response = SyliusRequest.get(get_endpoint, auth_headers)
     log_request_response(get_endpoint, get_response, headers=auth_headers)
-    AssertionStatusCode.assert_status_code_200(get_response)
-
-    retrieved_attribute = get_response.json()
-    assert retrieved_attribute["code"] == attribute_code
-    assert retrieved_attribute["translations"]["en_US"]["name"] == data["translations"]["en_US"]["name"]
 
     #Eliminar el atributo creado (DELETE)
     delete_endpoint = EndpointAttributes.code(attribute_code)
     delete_response = SyliusRequest.delete(delete_endpoint, auth_headers)
     log_request_response(delete_endpoint, delete_response, headers=auth_headers)
-    AssertionStatusCode.assert_status_code_204(delete_response)
 
     #Verificar que el atributo eliminado no existe (GET)
     get_after_delete_response = SyliusRequest.get(get_endpoint, auth_headers)


### PR DESCRIPTION
Se agregaron los TCs de la HU23: DELETE_ATTRIBUTES y eliminaron los mark de regression
TC138_Verificar_eliminar_atributo_existente
TC139_Verificar_que_no_se_permita_eliminar_atributo_con_code_inexistente
TC140_Verificar_que_no_se_permita_eliminar_atributo_sin_token
TC405_verificar_los_headers_respuesta_despues_de_eliminar_atributo
TC406_Verificar_que_el_atributo_eliminado_no_se_muestre
TC407_Verificar_no_permitir_eliminar_atributo_con_token_invalido
TC408_verificar_el_tiempo_respuesta_despues_de_eliminar_atributo
TC409_Verificar_los_headers_respuesta_despues_de_eliminar_atributo